### PR TITLE
Allow support for more reporters

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,9 @@ Everything is set up right now to be configured via customize or per project in 
             (mocha-environment-variables . "NODE_ENV=test")
             (mocha-options . "--recursive --reporter dot -t 5000")
             (mocha-project-test-directory . "test")
+            (mocha-reporter . "spec")
             )))
 ```
-
-I highly recommend using the "dot" reporter with Emacs. The ansi escaping code within emacs generally does a bad job with the other reporters 
 
 ## Running tests
 

--- a/mocha.el
+++ b/mocha.el
@@ -38,8 +38,13 @@
   :type 'string
   :group 'mocha)
 
-(defcustom mocha-options "--recursive --reporter dot"
+(defcustom mocha-options "--recursive"
   "Command line options to pass to mocha."
+  :type 'string
+  :group 'mocha)
+
+(defcustom mocha-reporter "dot"
+  "Name of reporter to use."
   :type 'string
   :group 'mocha)
 
@@ -60,7 +65,9 @@ From http://benhollis.net/blog/2015/12/20/nodejs-stack-traces-in-emacs-compilati
 
 (defun mocha-compilation-filter ()
   "Filter function for compilation output."
-  (ansi-color-apply-on-region compilation-filter-start (point-max)))
+  (ansi-color-apply-on-region compilation-filter-start (point-max))
+  (save-excursion
+    (replace-regexp "\\[[0-9]+[a-z]" "" nil (point-min) (point-max))))
 
 (define-compilation-mode mocha-compilation-mode "Mocha"
   "Mocha compilation mode."
@@ -102,6 +109,7 @@ IF TEST is specified run mocha with a grep for just that test."
          (target (if test (concat "--grep \"" test "\" ") ""))
          (node-command (concat mocha-which-node (if debug (concat " --debug=" mocha-debug-port) "")))
          (options (concat mocha-options (if debug " -t 21600000")))
+         (options (concat options (concat " --reporter " mocha-reporter)))
          (opts-file (mocha-opts-file path)))
     (when opts-file
       (setq options (concat options (if opts-file (concat " --opts " opts-file)))))

--- a/test/mocha-test.el
+++ b/test/mocha-test.el
@@ -36,3 +36,9 @@
      (f-touch integration-test-file)
      (should (s-contains? (concat "--opts " unit-opts-file) (mocha-generate-command nil unit-test-file)))
      (should-not (s-contains? "--opts" (mocha-generate-command nil integration-test-file))))))
+
+(ert-deftest mocha-test/mocha-generate-command/return-command-with-correct-reporter ()
+  (mocha-test/with-sandbox
+   (should (s-contains? "--reporter dot" (mocha-generate-command nil)))
+   (let ((mocha-reporter "spec"))
+     (should (s-contains? "--reporter spec" (mocha-generate-command nil))))))


### PR DESCRIPTION
This adds support for specifying reporters, which can be configured via the `mocha-reporter` reporter. Some reporters use CSI ansi codes (movement), which must be cleared.