### PR TITLE
Update README.md instructions to run make install

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Install [Cask](https://github.com/cask/cask) if you haven't already.
 
 Install the dependencies:
 
-    $ cask install
+    $ make install
 
 Run the tests with:
 


### PR DESCRIPTION
cask install doesn't run npm install in the sample project