### PR TITLE
Keeping compilation buffer alive and implementing (mocha-run-last)

### DIFF
--- a/mocha.el
+++ b/mocha.el
@@ -170,8 +170,8 @@ if you want to use `mocha-run-last'.
       (compilation-start test-command-to-run 'mocha-compilation-mode (lambda (m) (buffer-name)))
 
       ;; memorize last test, used in mocha-run-last
-      (set (make-local-variable 'mocha-file) mocha-file)
-      (set (make-local-variable 'mocha-test) test)
+      (set (make-local-variable 'mocha-last-file) mocha-file)
+      (set (make-local-variable 'mocha-last-test) test)
       )))
 
 (defun mocha-run-last ()
@@ -183,7 +183,7 @@ Relies on the presence of *mocha tests* buffer to retrieve settings.
   (let ((buf (get-buffer "*mocha tests*")))
     (if buf
         (with-current-buffer buf
-          (mocha-run mocha-file mocha-test)
+          (mocha-run mocha-last-file mocha-last-test)
           )
       (message "Mocha buffer not found. You first need to use other mocha test commands.")
       )


### PR DESCRIPTION
Hi friends,

I first decided to peep at mocha.el code when I found myself tired of seeing its compilation window jumping from one side to another. Maybe I missed something but I don't know why the mocha buffer was killed for each run. So I changed that and my life is easier ! 

And from there it was so easy to implement this (mocha-run-last) ,  so handy when you're working on the tested code (ref #16).

I hope you'll like it. Cask is happy.
