### PR TITLE
Imenu integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ Stack traces for failing tests have clickable links to the file and line that fa
 
 `mocha-test-at-point` uses [js2-mode](https://github.com/mooz/js2-mode) to find the nearest `describe` or `it` and extract the description string from it. As such, it only works in JavaScript files that have js2-mode set as the major mode.
 
+Mocha includes an `imenu` function that builds an index matching the `describe` and `it` tree. You can enable this index function by setting `imenu-create-index-function` to `mocha-make-imenu-alist` or using `(mocha-toggle-imenu-function)`.
+
 ## Debugging Tests
 
 Each of the test functions has a debug analog: `mocha-debug-project`, `mocha-debug-file`, and `mocha-debug-at-point`. Using these functions depends on having [realgud](https://github.com/rocky/emacs-dbgr) installed and loaded.

--- a/mocha.el
+++ b/mocha.el
@@ -276,6 +276,7 @@ If there is no wrapping 'describe' or 'it' found, return nil."
                        (push (cons (mocha--get-callsite-name node) my-children) (car children-stack)))
                    (push (list (cons "*declaration*" (js2-node-abs-pos node))) children-stack)
                    t))
+                (end-p nil)             ; We only want to visit the others once
                 ((string= callee-name "it")
                  (push (cons (mocha--get-callsite-name node) (js2-node-abs-pos node))
                        (car children-stack)))

--- a/test/mocha-test.el
+++ b/test/mocha-test.el
@@ -120,3 +120,63 @@
                      "C:\\Users\\name\\node_modules\\jsdom\\lib\\jsdom\\browser\\Window.js"))
     (should (string= (match-string (nth 2 (car node-error-regexp-alist)) line) "477"))
     (should (string= (match-string (nth 3 (car node-error-regexp-alist)) line) "19"))))
+
+
+;;;; imenu integration
+
+(ert-deftest mocha-test/make-imenu-alist ()
+  (with-temp-buffer
+    (insert "
+describe('something', function() {
+  beforeEach(() => console.log('sometihng'));
+  it(\"does something\", () => {});
+  describe(\"on the inside\", function() {
+    beforeAll(setupFunction);
+    afterEach(partialReset);
+    it(\"does some more, but not tested\");
+    features.forEach(feat => {
+        it(\"feature test: \" + feat, () => {
+          // ...
+        })
+    });
+    afterAll(totalReset);
+  });
+});
+
+describe(\"another top-level\", () => {});
+afterAll(() => {});")
+    (js2-mode)
+    (js2-parse)
+    (require 'mocha)
+    (let (imenu-max-item-length)
+      (should (equal
+               (mocha-make-imenu-alist)
+               '(("describe something" .
+                  (("*declaration*" . 2)
+                   ("beforeEach" . 39)
+                   ("it does something" . 85)
+                   ("describe on the inside" .
+                    (("*declaration*" . 119)
+                     ("beforeAll" . 162)
+                     ("afterEach" . 192)
+                     ("it does some more, but not tested" . 221)
+                     ("it \"feature test: \" + feat" . 298)
+                     ("afterAll" . 374)))))
+                 ("describe another top-level" .
+                  (("*declaration*" . 407)))
+                 ("afterAll" . 448)))))))
+
+(ert-deftest mocha-test/toggle-imenu-function ()
+  (with-temp-buffer
+    (insert "function setUp() {}\ndescribe(\"top-level\", () => {it('works');});")
+    (js2-mode)
+    (js2-parse)
+    (let ((prev (imenu--make-index-alist)))
+      (mocha-toggle-imenu-function)
+      (should (equal (imenu--make-index-alist)
+                     '(("*Rescan*" . -99)
+                       ("describe top-level"
+                        ("*declaration*" . 21)
+                        ("it works" . 50)))))
+      (mocha-toggle-imenu-function)
+      (should (equal (imenu--make-index-alist) prev)))))


### PR DESCRIPTION
This PR adds a customized `imenu` function that creates an index mirroring the `define`, `it` tree. So the following file:

```js
describe('something', function() {
  beforeEach(() => console.log('something'));

  it("does something", () => {});

  describe("on the inside", function() {
    beforeAll(setupFunction);
    afterEach(partialReset);

    it(\"does some more, but not tested");

    features.forEach(feat => {
        it("feature test: " + feat, () => {
          // ...
        })
    });

    afterAll(totalReset);
  });
});

describe("another top-level", () => {});

afterAll(() => {});
```

would generate the following imenu tree:

```lisp
(("describe something" .
  ("*declaration*"
   "beforeEach"
   "it does something"
   ("describe on the inside" .
    ("*declaration*"
     "beforeAll"
     "afterEach"
     "it does some more, but not tested"
     "it \"feature test: \" + feat"
     "afterAll"))))
 ("describe another top-level" . ("*declaration*"))
 "afterAll")
```

The imenu function can be enabled and disabled using `mocha-toggle-imenu-function` (defaults to disabled). If you like this addition, I can also add a note to the README