### PR TITLE
Find current test even when point is in comment

### DIFF
--- a/mocha.el
+++ b/mocha.el
@@ -213,7 +213,7 @@ If we reach the root without finding what we are looking for return nil."
 When a 'describe' or 'it' is found, return the first argument of that call.
 If js2-mode is not enabled in the buffer, returns nil.
 If there is no wrapping 'describe' or 'it' found, return nil."
-  (let ((node (js2-node-at-point)))
+  (let ((node (js2-node-at-point nil t)))
     (mocha-walk-up-to-it node)))
 
 ;;;###autoload

--- a/test/mocha-test.el
+++ b/test/mocha-test.el
@@ -101,6 +101,14 @@
     (js2-reparse)
     (should (string= (mocha-find-current-test) "does as expected"))))
 
+(ert-deftest mocha-test/mocha-find-current-test/point-in-comment ()
+  (with-temp-buffer
+    (insert "it('does as expected', function() { // Imporant ")
+    (save-excursion (insert "test\n});"))
+    (js2-mode)
+    (js2-parse)
+    (should (string= (mocha-find-current-test) "does as expected"))))
+
 (ert-deftest mocha-test/mocha-find-current-test/js-mode-error ()
   (with-temp-buffer
     (insert "it('does as expected', function() {")


### PR DESCRIPTION
Currently when point is at a comment, `mocha-find-current-test` fails
even if inside a test since comment nodes are outside the main js2 ast
tree. We therefore start our search in those cases at the point
immediately after the comment. E.g.:

```js
it('does the right thing', function() { // important |test
  expect(1 + 1).toBe(2)
});
```