### PR TITLE
Fix invalid use of "--grep" regexp option

### DIFF
--- a/mocha.el
+++ b/mocha.el
@@ -128,7 +128,7 @@ MOCHA-PROJECT-TEST-DIRECTORY.
 
 IF TEST is specified run mocha with a grep for just that test."
   (let* ((path (or mocha-file mocha-project-test-directory))
-         (target (if test (concat "--grep \"" test "\" ") ""))
+         (target (if test (concat "--fgrep '" test "' ") ""))
          (node-command (concat mocha-which-node (if debug (concat " --debug=" mocha-debug-port) "")))
          (options (concat mocha-options (if debug " -t 21600000")))
          (options (concat options (concat " --reporter " mocha-reporter)))

--- a/sample-project/test/parse-int-test.js
+++ b/sample-project/test/parse-int-test.js
@@ -3,7 +3,7 @@ const expect = require('chai').expect;
 const myParseInt = require('../src/parse-int.js');
 
 describe('my parse int', function () {
-  it('turns a string into a number', function () {
+  it('turns a string into a number (integer)', function () {
     let expected = myParseInt('10');
 
     expect(expected).to.equal(10);


### PR DESCRIPTION
Test names are passed as literal strings.

Fixes issue (_grep_ doesn't match) for test cases Like

```javascript
describe("Currency", function() {
    it("can parse $", function() {
        assert.ok("Fixme", undefined);
    });
});

```