### PR TITLE
Add support for indium debugger

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "6.0.0"
+  - "8.9.0"
 sudo: false
 before_install:
   - curl -fsSkL https://gist.github.com/rejeep/ebcd57c3af83b049833b/raw > x.sh && source ./x.sh
@@ -10,6 +10,8 @@ before_install:
 env:
   - EVM_EMACS=emacs-24.4-travis
   - EVM_EMACS=emacs-24.5-travis
+  - EVM_EMACS=emacs-25.1-travis
+  - EVM_EMACS=emacs-25.2-travis
 script:
   - emacs --version
   - make test

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Mocha includes an `imenu` function that builds an index matching the `describe` 
 
 Each of the test functions has a debug analog: `mocha-debug-project`, `mocha-debug-file`, and `mocha-debug-at-point`. Using these functions depends on having a javascript debugger installed and loaded. The debuggers with built-in support are:
 
-* [realgud](https://github.com/rocky/emacs-dbgr)
+* [realgud](https://github.com/realgud/realgud)
 * [indium](https://indium.readthedocs.io/en/latest/debugger.html)
 
 The `realgud` debugging buffer takes the same commands as the standard node CLI debugger. Some useful ones are:

--- a/README.md
+++ b/README.md
@@ -52,9 +52,12 @@ Mocha includes an `imenu` function that builds an index matching the `describe` 
 
 ## Debugging Tests
 
-Each of the test functions has a debug analog: `mocha-debug-project`, `mocha-debug-file`, and `mocha-debug-at-point`. Using these functions depends on having [realgud](https://github.com/rocky/emacs-dbgr) installed and loaded.
+Each of the test functions has a debug analog: `mocha-debug-project`, `mocha-debug-file`, and `mocha-debug-at-point`. Using these functions depends on having a javascript debugger installed and loaded. The debuggers with built-in support are:
 
-The provided debugging buffer takes the same commands as the standard node CLI debugger. Some useful ones are:
+* [realgud](https://github.com/rocky/emacs-dbgr)
+* [indium](https://indium.readthedocs.io/en/latest/debugger.html)
+
+The `realgud` debugging buffer takes the same commands as the standard node CLI debugger. Some useful ones are:
  * `s` to step in
  * `o` to step out
  * `n` to step over

--- a/mocha.el
+++ b/mocha.el
@@ -53,6 +53,35 @@
   :group 'mocha
   :safe #'stringp)
 
+(defcustom mocha-debugger 'realgud
+  "Which debugger to use."
+  :type '(choice (const :tag "realgud" realgud))
+  :group 'mocha
+  :safe #'mocha-debugger-name-p)
+
+(defvar mocha-debuggers
+  '((realgud :must-bind realgud:nodejs :attach-fn mocha-realgud:nodejs-attach))
+  "List of debuggers which can be attached with `mocha-debug'.
+Each entry is a list of (name . props), where NAME is a symbol
+that `mocha-debugger' can take on, and PROPS is a plist with two keys:
+
+:MUST-BIND is the name of a function that is bound when the
+debugger is loaded.  Before running mocha in debug mode, the
+symbol is tested with `fboundp' and the debug run is aborted if
+the result is nil.
+
+:ATTACH-FN is a function to `funcall' after the debug run has
+been started.  The function will be passed the following arguments:
+NODE - the value of `mocha-which-node' used for the debug run.
+BUF - the name of the buffer with the debug run command output.
+PORT - the value of `mocha-debug-port' when the debug run was started.
+MOCHA-FILENAME - the filename that `mocha-debug' was called on, if any.
+TEST - the name of the test that `mocha-debug' was called on, if any.")
+
+(defun mocha-debugger-name-p (val)
+  "Return nil if VAL is an invalid debugger name."
+  (assq val mocha-debuggers))
+
 (defcustom mocha-debug-port "5858"
   "The port number to debug mocha tests at."
   :type 'string
@@ -142,28 +171,46 @@ IF TEST is specified run mocha with a grep for just that test."
             target
             path)))
 
+(defun mocha-debugger-get (debugger-name prop)
+  "Return the value of debugger DEBUGGER-NAME's prop PROP."
+  (let ((props (assq debugger-name mocha-debuggers)))
+    (unless props (error "Unknown debugger %s" debugger-name))
+    (plist-get (cdr props) prop)))
+
+(defun mocha-check-debugger ()
+  "Ensure that the selected debugger is loaded."
+  (let ((cmd (mocha-debugger-get mocha-debugger :must-bind)))
+    (unless (and cmd (fboundp cmd))
+      (user-error "%s is required to debug mocha" cmd))))
+
 (defun mocha-debug (&optional mocha-file test)
-  "Debug mocha using realgud.
+  "Run mocha and attach a debugger.
 
 If MOCHA-FILE is specified run just that file otherwise run
 MOCHA-PROJECT-TEST-DIRECTORY.
 
 IF TEST is specified run mocha with a grep for just that test."
-  (if (not (fboundp 'realgud:nodejs))
-      (message "realgud is required to debug mocha")
-    (save-some-buffers (not compilation-ask-about-save)
+  (mocha-check-debugger)
+  (save-some-buffers (not compilation-ask-about-save)
                      (when (boundp 'compilation-save-buffers-predicate)
                        compilation-save-buffers-predicate))
 
   (when (get-buffer "*mocha tests: debug*")
     (kill-buffer "*mocha tests: debug*"))
   (let ((test-command-to-run (mocha-generate-command t mocha-file test))
-        (root-dir (mocha-find-project-root))
-        (debug-command (concat mocha-which-node " debug localhost:" mocha-debug-port)))
+        (root-dir (mocha-find-project-root)))
     (with-current-buffer (get-buffer-create "*mocha tests: debug*")
       (setq default-directory root-dir)
       (compilation-start test-command-to-run 'mocha-compilation-mode (lambda (m) (buffer-name)))
-      (realgud:nodejs debug-command)))))
+      (funcall (mocha-debugger-get mocha-debugger :attach-fn)
+               mocha-which-node (buffer-name) mocha-debug-port mocha-file test))))
+
+(defun mocha-realgud:nodejs-attach (node buf port file test)
+  "Attach `realgud:nodejs' to a running node process.
+NODE, BUF, PORT, FILE, and TEST are described in
+`mocha-debuggers' under :attach-fn."
+  (ignore buf file test)
+  (realgud:nodejs (concat node " debug localhost:" port)))
 
 (defun mocha-run (&optional mocha-file test)
   "Run mocha in a compilation buffer.

--- a/test/mocha-test.el
+++ b/test/mocha-test.el
@@ -135,19 +135,11 @@
     (setq compilation-environment '("TEST=abc"))
     (let ((command (if (memq system-type '(windows-nt ms-dos))
                        "echo %TEST%"
-                     "echo $TEST"))
-          (old-mocha-generate-command (symbol-function 'mocha-generate-command))
-          (old-mocha-find-project-root (symbol-function 'mocha-find-project-root))
-          (old-cd (symbol-function 'cd)))
-      (unwind-protect
-          (progn
-            (fset 'mocha-generate-command (lambda (debug &optional mocha-file test) command))
-            (fset 'mocha-find-project-root (lambda () "."))
-            (fset 'cd (lambda (dir) "."))
-            (mocha-run))
-        (fset 'mocha-generate-command old-mocha-generate-command)
-        (fset 'mocha-find-project-root old-mocha-find-project-root)
-        (fset 'cd old-cd))
+                     "echo $TEST")))
+      (mocha-dynamic-flet ((mocha-generate-command (debug &optional mocha-file test) command)
+                           (mocha-find-project-root () ".")
+                           (cd (dir) "."))
+        (mocha-run))
       (sit-for 2)
       (with-current-buffer "*mocha tests*"
         (goto-char 0)

--- a/test/mocha-test.el
+++ b/test/mocha-test.el
@@ -139,7 +139,10 @@
       (mocha-dynamic-flet ((mocha-generate-command (debug &optional mocha-file test) command)
                            (mocha-find-project-root () ".")
                            (cd (dir) ".")
-                           (start-process))
+                           ;; In 24.x, (fboundp 'start-process)
+                           ;; determines whether async compilation can
+                           ;; run. In 25.x, it's (fboundp 'make-process)
+                           (start-process) (make-process))
         (mocha-run))
       (with-current-buffer "*mocha tests*"
         (goto-char 0)

--- a/test/mocha-test.el
+++ b/test/mocha-test.el
@@ -244,10 +244,13 @@ afterAll(() => {});")
     (should (string-match-p "unknown-debugger" (cadr err)))))
 
 (ert-deftest mocha-test/mocha-debug/errors-if-debugger-is-unbound ()
-  (mocha-dynamic-flet ((realgud:nodejs))
+  (mocha-dynamic-flet ((realgud:nodejs) (indium-connect-to-nodejs))
     (let* ((mocha-debugger 'realgud)
            (err (should-error (mocha-debug) :type 'user-error)))
-      (should (string-match-p "realgud" (cadr err))))))
+      (should (string-match-p "realgud" (cadr err))))
+    (let* ((mocha-debugger 'indium)
+           (err (should-error (mocha-debug) :type 'user-error)))
+      (should (string-match-p "indium" (cadr err))))))
 
 (ert-deftest mocha-test/mocha-debug/realgud-debugger ()
   (let ((addr "fc0b9f1a-0113-4368-a370-ff1a888ae6bb")
@@ -263,3 +266,17 @@ afterAll(() => {});")
       (mocha-debug))
     (should (equal realgud-calls (list (list (concat mocha-which-node " debug localhost:"
                                                      mocha-debug-port)))))))
+
+(ert-deftest mocha-test/mocha-debug/indium-debugger ()
+  (let ((addr "fc0b9f1a-0113-4368-a370-ff1a888ae6bb")
+        (mocha-debugger 'indium)
+        indium-calls)
+    (mocha-dynamic-flet ((mocha-generate-command
+                          (debug &optional mocha-file test)
+                          (concat "echo 'Debugger listening on ws://127.0.0.1:"
+                                  mocha-debug-port "/" addr "'"))
+                         (mocha-find-project-root () ".")
+                         (cd (dir) ".")
+                         (indium-connect-to-nodejs (&rest args) (push args indium-calls)))
+      (mocha-debug))
+    (should (equal indium-calls (list (list "127.0.0.1" mocha-debug-port addr))))))

--- a/test/mocha-test.el
+++ b/test/mocha-test.el
@@ -138,9 +138,9 @@
                      "echo $TEST")))
       (mocha-dynamic-flet ((mocha-generate-command (debug &optional mocha-file test) command)
                            (mocha-find-project-root () ".")
-                           (cd (dir) "."))
+                           (cd (dir) ".")
+                           (start-process))
         (mocha-run))
-      (sit-for 2)
       (with-current-buffer "*mocha tests*"
         (goto-char 0)
         (should (search-forward (concat "\n" command "\n") nil t))

--- a/test/mocha-test.el
+++ b/test/mocha-test.el
@@ -234,3 +234,32 @@ afterAll(() => {});")
                      ("describe top-level"
                       ("*declaration*" . 21)
                       ("test that it works" . 50)))))))
+
+
+;;;; mocha-debug
+
+(ert-deftest mocha-test/mocha-debug/errors-if-debugger-is-unknown ()
+  (let* ((mocha-debugger 'unknown-debugger)
+         (err (should-error (mocha-debug))))
+    (should (string-match-p "unknown-debugger" (cadr err)))))
+
+(ert-deftest mocha-test/mocha-debug/errors-if-debugger-is-unbound ()
+  (mocha-dynamic-flet ((realgud:nodejs))
+    (let* ((mocha-debugger 'realgud)
+           (err (should-error (mocha-debug) :type 'user-error)))
+      (should (string-match-p "realgud" (cadr err))))))
+
+(ert-deftest mocha-test/mocha-debug/realgud-debugger ()
+  (let ((addr "fc0b9f1a-0113-4368-a370-ff1a888ae6bb")
+        (mocha-debugger 'realgud)
+        realgud-calls)
+    (mocha-dynamic-flet ((mocha-generate-command
+                          (debug &optional mocha-file test)
+                          (concat "echo 'Debugger listening on ws://127.0.0.1:"
+                                  mocha-debug-port "/" addr "'"))
+                         (mocha-find-project-root () ".")
+                         (cd (dir) ".")
+                         (realgud:nodejs (&rest args) (push args realgud-calls)))
+      (mocha-debug))
+    (should (equal realgud-calls (list (list (concat mocha-which-node " debug localhost:"
+                                                     mocha-debug-port)))))))

--- a/test/test-helper.el
+++ b/test/test-helper.el
@@ -15,3 +15,33 @@
      (f-touch (f-join mocha-test/sandbox-path "package.json"))
      (let ((default-directory (f-slash mocha-test/sandbox-path)))
        (f-with-sandbox default-directory ,@body))))
+
+(defmacro mocha-dynamic-flet (bindings &rest body)
+  "Set BINDINGS and execute BODY.
+BINDINGS is a list of (name arglist body) lists of functions to
+dynamically redefine, or simply (name).  In the latter case, name
+will be given to `fmakunbound'."
+  ;; can't use noflet because it doesn't support 24.x
+  (declare (debug ((&rest (&define name &optional lambda-list def-body)) body))
+           (indent 1))
+  (let ((old-new-pairs
+         (mapcar (lambda (b) (cons (make-symbol (format "old-%s" (car b))) b))
+                 bindings)))
+    `(let ,(mapcar (lambda (old-new)
+                     `(,(car old-new) (symbol-function ',(cadr old-new))))
+                   old-new-pairs)
+       (unwind-protect
+           (progn
+             ,@(mapcar (lambda (b)
+                         (if (cdr b)
+                             `(setf (symbol-function ',(car b))
+                                    #'(lambda ,(cadr b) ,@(cddr b)))
+                           `(fmakunbound ',(car b))))
+                       bindings)
+             ,@body)
+         ,@(mapcar (lambda (old-new)
+                     `(setf (symbol-function ',(cadr old-new)) ,(car old-new)))
+                   old-new-pairs)))))
+
+(provide 'test-helper)
+;;; test-helper.el ends here


### PR DESCRIPTION
This PR includes some refactoring to support easy customization of debuggers as well as an implementation of the [`indium`](https://github.com/NicolasPetton/Indium) debugger. (The existing `realgud` debugger is kept and is still the default)