### PR TITLE
Test updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "6.0.0"
+  - "8.9.0"
 sudo: false
 before_install:
   - curl -fsSkL https://gist.github.com/rejeep/ebcd57c3af83b049833b/raw > x.sh && source ./x.sh
@@ -10,6 +10,8 @@ before_install:
 env:
   - EVM_EMACS=emacs-24.4-travis
   - EVM_EMACS=emacs-24.5-travis
+  - EVM_EMACS=emacs-25.1-travis
+  - EVM_EMACS=emacs-25.2-travis
 script:
   - emacs --version
   - make test

--- a/test/mocha-test.el
+++ b/test/mocha-test.el
@@ -135,19 +135,11 @@
     (setq compilation-environment '("TEST=abc"))
     (let ((command (if (memq system-type '(windows-nt ms-dos))
                        "echo %TEST%"
-                     "echo $TEST"))
-          (old-mocha-generate-command (symbol-function 'mocha-generate-command))
-          (old-mocha-find-project-root (symbol-function 'mocha-find-project-root))
-          (old-cd (symbol-function 'cd)))
-      (unwind-protect
-          (progn
-            (fset 'mocha-generate-command (lambda (debug &optional mocha-file test) command))
-            (fset 'mocha-find-project-root (lambda () "."))
-            (fset 'cd (lambda (dir) "."))
-            (mocha-run))
-        (fset 'mocha-generate-command old-mocha-generate-command)
-        (fset 'mocha-find-project-root old-mocha-find-project-root)
-        (fset 'cd old-cd))
+                     "echo $TEST")))
+      (mocha-dynamic-flet ((mocha-generate-command (debug &optional mocha-file test) command)
+                           (mocha-find-project-root () ".")
+                           (cd (dir) "."))
+        (mocha-run))
       (sit-for 2)
       (with-current-buffer "*mocha tests*"
         (goto-char 0)

--- a/test/mocha-test.el
+++ b/test/mocha-test.el
@@ -139,7 +139,10 @@
       (mocha-dynamic-flet ((mocha-generate-command (debug &optional mocha-file test) command)
                            (mocha-find-project-root () ".")
                            (cd (dir) ".")
-                           (start-process))
+                           ;; In 24.x, (fboundp 'start-process)
+                           ;; determines whether async compilation can
+                           ;; run. In 25.x, it's (fboundp 'make-process)
+                           (start-process) (make-process))
         (mocha-run))
       (with-current-buffer "*mocha tests*"
         (goto-char 0)

--- a/test/mocha-test.el
+++ b/test/mocha-test.el
@@ -138,9 +138,9 @@
                      "echo $TEST")))
       (mocha-dynamic-flet ((mocha-generate-command (debug &optional mocha-file test) command)
                            (mocha-find-project-root () ".")
-                           (cd (dir) "."))
+                           (cd (dir) ".")
+                           (start-process))
         (mocha-run))
-      (sit-for 2)
       (with-current-buffer "*mocha tests*"
         (goto-char 0)
         (should (search-forward (concat "\n" command "\n") nil t))

--- a/test/test-helper.el
+++ b/test/test-helper.el
@@ -15,3 +15,33 @@
      (f-touch (f-join mocha-test/sandbox-path "package.json"))
      (let ((default-directory (f-slash mocha-test/sandbox-path)))
        (f-with-sandbox default-directory ,@body))))
+
+(defmacro mocha-dynamic-flet (bindings &rest body)
+  "Set BINDINGS and execute BODY.
+BINDINGS is a list of (name arglist body) lists of functions to
+dynamically redefine, or simply (name).  In the latter case, name
+will be given to `fmakunbound'."
+  ;; can't use noflet because it doesn't support 24.x
+  (declare (debug ((&rest (&define name &optional lambda-list def-body)) body))
+           (indent 1))
+  (let ((old-new-pairs
+         (mapcar (lambda (b) (cons (make-symbol (format "old-%s" (car b))) b))
+                 bindings)))
+    `(let ,(mapcar (lambda (old-new)
+                     `(,(car old-new) (symbol-function ',(cadr old-new))))
+                   old-new-pairs)
+       (unwind-protect
+           (progn
+             ,@(mapcar (lambda (b)
+                         (if (cdr b)
+                             `(setf (symbol-function ',(car b))
+                                    #'(lambda ,(cadr b) ,@(cddr b)))
+                           `(fmakunbound ',(car b))))
+                       bindings)
+             ,@body)
+         ,@(mapcar (lambda (old-new)
+                     `(setf (symbol-function ',(cadr old-new)) ,(car old-new)))
+                   old-new-pairs)))))
+
+(provide 'test-helper)
+;;; test-helper.el ends here


### PR DESCRIPTION
In order to make #56 be a cleaner PR, I pulled out some testing updates into this one to apply first. The let-binding of `start-process` and `make-process` feels like a huge hack, but I needed to force synchronous compilation to avoid a race condition in the test that ensured that setting a buffer-local compilation-environment worked.