### PR TITLE
Don't kill buffer explicitly in mocha-run

### DIFF
--- a/mocha.el
+++ b/mocha.el
@@ -237,8 +237,6 @@ If MOCHA-FILE is specified run just that file otherwise run
 MOCHA-PROJECT-TEST-DIRECTORY.
 
 IF TEST is specified run mocha with a grep for just that test."
-  (when (get-buffer "*mocha tests*")
-    (kill-buffer "*mocha tests*"))
   (let ((test-command-to-run (mocha-generate-command nil mocha-file test))
         (default-directory (mocha-find-project-root))
         (compilation-buffer-name-function (lambda (_) "" "*mocha tests*")))


### PR DESCRIPTION
`compile` takes care of erasing buffer and killing existing process automatically. 

This PR closes #52 

Not sure how to add automated tests for this, but I've been using this for a while without issues on 25.2 and 26