### PR TITLE
Add `FORCE_COLOR=1` to default environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The package can be installed via MELPA. The package name is mocha.
 
 Everything is set up right now to be configured via customize or per project in a `.dir-locals.el` file. You can find all options by looking at the `mocha` group in the customize interface. Below is an example configuration:
 
-```
+```elisp
 ((nil . (
             (mocha-which-node . "/Users/ajs/.nvm/versions/node/v4.2.2/bin/node")
             (mocha-command . "node_modules/.bin/mocha")

--- a/mocha.el
+++ b/mocha.el
@@ -35,7 +35,7 @@
   :group 'mocha
   :safe #'stringp)
 
-(defcustom mocha-environment-variables nil
+(defcustom mocha-environment-variables "FORCE_COLOR=1"
   "Environment variables to run mocha with."
   :type 'string
   :group 'mocha


### PR DESCRIPTION
To cut a long story short, Mocha's coloured output is [causing Emacs users](https://emacs.stackexchange.com/questions/27218/why-is-there-so-often-ugly-output-in-node-js-compilation-buffers) grief because Emac's default `compile` command chokes on ANSI escape sequences when emitted from `make -k` feedback. @plroebuck identified [the crux](https://github.com/chalk/supports-color/issues/88) of the problem  in [`chalk/supports-color`](https://github.com/chalk/supports-color) handling of `TERM=dumb` environments.

I submitted [a pull-request](https://github.com/chalk/supports-color/pull/89) which fixes this, and simultaneously fixes `compiler-mode`'s problems whilst affecting the coloured output of `mocha.el`:

<img src="https://user-images.githubusercontent.com/2346707/49336492-572db100-f657-11e8-96fc-623bc9ae0803.png" width="45%" alt="Mocha.el: Before" valign="top" /> <img src="https://user-images.githubusercontent.com/2346707/49336502-6dd40800-f657-11e8-8bb7-019d7f6eaf53.png" alt="Mocha.el: After" width="45%" valign="top" />

Basically, the fix is to add `FORCE_COLOR=1` in the environment, which is picked up by the `supports-color` module as a user's wish to go and use coloured output anyway, irrespective o f the `TERM=dumb` variable being set in both compiler-modes.

We can merge this now, it won't get noticed because the package's highlighting is currently working fine. But users will notice once `chalk/supports-color#89` gets merged and shipped in a new release;  having this the default for `mocha-environment-variables` ensures there's absolutely no friction when it does. =)