### PR TITLE
Do not provide the test-helper feature

### DIFF
--- a/test/test-helper.el
+++ b/test/test-helper.el
@@ -43,5 +43,4 @@ will be given to `fmakunbound'."
                      `(setf (symbol-function ',(cadr old-new)) ,(car old-new)))
                    old-new-pairs)))))
 
-(provide 'test-helper)
 ;;; test-helper.el ends here


### PR DESCRIPTION
`test-helper.el` isn't a library intended to be loaded with
`require`. Instead it is loaded with `load` by `ert-runner` itself and
that does not use `require` to do so.

Because of that, it is confusing to `provide` a feature.  It also
wouldn't be possible to use `require` to reliably load `test-helper`
because that might, depending on the order of `load-path`, load the
`test-helper.el` of another package.

There aren't many packages left that have that defect but that's only
because I got them to fix this issue. It would be great if you could
fix it in your package as well.

This is also discussed at rejeep/ert-runner.el#38.